### PR TITLE
2024 05 10 revisions

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -2,85 +2,102 @@
 Halfcourt Jam is a basketball board game. 
 
 ## Objective
-The first player to score 15 points wins the game. 
+The first Team to score 11 points wins the game. 
 
 ## Components
 - **Board**: The board where the Hoopers will play. 
 - **Shot clock Marker**: this is used to show how many turns the team with the ball has to shoot. When this expires, the other team gets the ball. 
 - **Score Markers**: these show what the score is.
-- **10 Hooper Cards**: Each of these cards has a unique Hooper with different skills and abilities. In each game, you will play with just 5 of them. Each Hooper has a back side with an ability that is only available when they are Activated.
-- **10 Hooper Chits**: Each of these corrosponds with the Hooper Cards. These are the pieces you will actually move around on the board.
+- **10 Hooper Cards**: Each of these cards has a unique Hooper with different skills and abilities. In each game, you will play with just 3 of them. Each Hooper has a back side with an ability that is only available when they are Activated.
+- **10 Hooper Markers**: Each of these corrosponds with the Hooper Cards. These are the pieces you will actually move around on the board.
 - **1 Ball Die**: A 20-sided die which you will roll when you shoot or pass. The Ball tells you whether or not your shot or pass was successful.
-- **Hustle Mat**: Each Hooper starts in the Normal Zone. 
 - **Activation Markers**: Each Hoooper has a unique skill which is only used when they are Activated. These Markers show how close each Hooper is to being Activated.
+- **Action cards** Each Team has an identical set of action cards, which they use to set plays for their Hoopers. 
 
 ## Setup
 - Set up the board in the middle of the table
-- Place the Score Markers in the 0 spaces.
+- Place the Score Markers in the 0 space on the scoreboard.
 - Place the Shot Clock Marker on the 4 space of the Shot Clock Meter on the Board.
 
-Each player determines a team, either Purple or Yellow. Then each player will select 5 players each. 
+Each player determines a team, either Purple or Yellow. Then each Team will select 3 Hoopers each. 
 
-For your first game, you should use these two sets of players, and skip the draft:
-- **Yellow**: Harden, Wilt, Shane, Kyrie, and Ron
-- **Purple**: Lebron, Ray, Isiah, Hakeem, and Draymond
+For your first game, you should use these two sets of Hoopers, and skip the draft:
+- **Yellow**: TBD
+- **Purple**: TBD
 
-If this is not your first game, you will start by Drafting players onto your team:
+If this is not your first game, you will start by Drafting Hoopers onto your team:
 1. Sort all of the Hooper Cards by position. 
 2. Lay out all Point Guards. 
-3. Yellow selects a Point Guard, then Purple selects one. Discard the rest.
-4. Repeat this process for each position, alternating which player selects first.
+3. Each Team may ban one of the Point Guards, meaning that neither Team can take them.
+4. Yellow selects a Point Guard, then Purple selects one. Discard the rest.
+5. Repeat this process for each position, alternating which Teams selects first.
 
-Always start the game with the players in the spaces in the diagram below.
+Once you have selected your 3 Hoopers, place their card in front of you on the normal side (not their "activated" side), and place their marker on the board.
+
+Always start the game with the Hoopers in the spaces in the diagram below.
+
+{{ add diagram }}
 
 # Gameplay
 Yellow always has the ball first. 
 
 ## Possession 
-At the start of each possession, the offense chooses a player and moves them to any space on the outside border, past the 3 point line, with the ball. During a possession, the offense and defense will alternate taking turns, beginning with the defense.
+When a Hoooper gains possession of the ball, move the shot clock marker to 3. A possession will be made up of a maximum of 3 rounds. During a round, each of your Hoopers will take an action. 
 
-A possession ends after the ball is stolen, the defense rebounds the ball, the Shot Clock expires, or the offense scores. 
+A possession ends if the defense steals the ball, the defense rebounds the ball, the Shot Clock expires, or the offense scores. When any of these occur, the defense gains possession of the ball, and the shot clock returns to 3. 
 
-## Turn
-On your turn, you make take actions. If you are on offense, you may take up to 4 actions. If you are on defense, you can take up to 3 actions. Each Hooper on your team can only take 1 Action per turn.
+## Round
+At the beginning of each round, both teams set their plays. In front of each of your Hooper cards, place one face-down action card. This is the action you intend for them to perform. The order of Hoopers does not matter: during your turn you can resolve them in any order you want. 
 
-Here are the actions available:
+Once both Teams have set their 3 action cards face-down, take turns revealing and resolving them one at a time, beginning with the offense.
 
 ### Actions
+
+The action deck has a relatively small number of options. The effect of each action is determined by the stats on your Hooper's card.
 
 #### Move
 The number of spaces a Hooper with this action is determined by their Speed. 
 
 - Your Hooper may move into the space of an opposing Hooper. But you cannot have 2 of our own Hoopers on a space.
-- Screens: With your final move, you may move halfway into another space. This indicates that you are setting a screen between the two spaces. While your Hooper is there, no other Hooper can move between these spaces along the border where you are setting your screen. Other Hoopers may still occupy each of the spaces your Hooper is screening between.
-- 3 in the Key: If you start your turn with a player in the key, and you do not move them out before your turn ends, the other team gets a Free Throw. 
+- Screens: With your final move, you may move halfway into another space. This indicates that you are setting a screen between the two spaces. While your Hooper is there, Hoopers from the other team can move between these spaces along the border where you are setting your screen. Other Hoopers may still occupy each of the spaces your Hooper is screening between.
 
 #### Pass
-If your Hooper has the ball, they may pass it to any teammate. However, you must roll the Ball to determine if it was successful. Find all opponent Hoopers who are on or adjacent to the passer's space, or the receiver's space. Tally up the total Hands stats of the opponents in all Defensive spaces. That is your difficulty score. Roll to Ball. If your roll is higher than that number, the pass is complete. If not, the defending team takes the ball, and begins their possession. 
+If your Hooper has the ball, they may pass it to any teammate. However, you must roll the Ball to determine if it was successful. Find all opponent Hoopers who are on the passer's space, or the receiver's space. Tally up the total defense stats of the opponents in all Defensive spaces. That is your difficulty score. Roll to Ball. If your roll is higher than that number, the pass is complete. If not, the defending team takes the ball, and begins their possession. The defense may give the ball to any of their Hoopers in the passer's space, or the intended recipient's space.
 
 #### Shoot
-If your Hooper has the ball, they may shoot. However, you must roll the Ball to know if the shot went in. Start with the Shooting Difficulty number in your Hooper's space. Then, add to this difficulty if there is an opposing Hooper in your space. If the opponent is taller than you, add 15. Finally, subtract your Hooper's Shooter Bonus stat. This total is your Shot Difficulty. Roll the Ball. If your roll is higher than your Shot Difficulty, the shot is good. If not, the shot is a miss.
+Roll the Ball to determine if the shot went in. Here is how to calculate the shot difficulty: 
 
-*Example: your Hooper is shooting from a space that has a difficulty of 8. There is an opponent in that space who is the same height. This pushes our difficulty to 18. But our Hooper has a Shooter Bonus of 6. This means that our Difficulty is 12. We must roll a 13 or higher to make the shot.*
+- Start with the Shooting Difficulty number in your Hooper's space, which is printed on the board.
+- If there is an opponent on your space, add their Defense stat. 
+- Subtract your Hooper's Shooter Bonus stat. 
 
-- Minimum and Maximum difficulty: The lowest difficulty a shot can have is 1, and the highest is 19. In other words, there is *always a chance* to make the shot or miss the shot, regardless of how hard or easy it is.
-- Rebounding: If you miss the shot, the rebound goes to the team who has more hoppers 1 space away from the rim. Tally up the defensive stats of the Hoopers 1 space from  the rim. Whichever team has more total defense under the rim gets the ball. If the defending team got the rebound, they immediately begin a possession. If the offense got the rebound, the Shot Clock is reset, and the defense takes their next turn as usual.
+This total is your Shot Difficulty. Roll the Ball. If your roll is higher than your Shot Difficulty, the shot is good. If not, the shot is a miss.
+
+*Example: your Hooper is shooting from a space that has a difficulty of 8. There is an opponent on the space whose Defense stat is 7. But our Hooper has a Shooter Bonus of 6. This means that our Difficulty is 9. We must roll a 10 or higher to make the shot.*
+
+The lowest difficulty a shot can have is 1, and the highest is 19. In other words, there is *always a chance* to make the shot or miss the shot, regardless of how hard or easy it is.
+
+**Rebounding**: If you miss the shot, the rebound goes to the team who has more Hoopers in the space directly below the rim. If there are no Hoopers in that space, the team with the most Hoopers in the next arc of spaces rebounds the ball. Continue outward until there is a region containing at least one Hooper. If that region has an equal number of Hoopers from each team, the tie always goes to the Defense. If your team rebounds the ball and you have multiple Hoopers in that region, you decide who gets the ball. If the defending team got the rebound, they immediately begin a possession and set the Shot Clock to 3. If the offense got the rebound, the Shot Clock is set to 2.
+
+### Audibles
+
+When revealing an action card for one of your Hoopers, you may always do a different action than what is printed on the card, but with a penalty. You may: 
+
+- **Move** half the numbers of spaces (rounded down) that you could normally move.
+- **Shoot**, but with 5 additional difficulty added to the shot.
+- **Pass**, but with 5 additional difficulty added to the pass.
+
+If you ever reveal an Action that you cannot play (for example, the card you reveal says pass or shoot, and that Hooper does not have the ball), you must do a different action with a penalty.
 
 ### Hustle Plays
-Each Hooper can be in one of 3 Energy states: 
+On your turn, you may play a card from your hand for a Hooper who already revealed their Action card. This is called a Hustle Play. After you perform this second action for them, you Exhaust them: turn the card to face horizontally. When Exhausted, a Hooper will not take *any* actions on the following round. At the end of the next round, turn them to face vertically as usual again. You may only make a Hustle Play with a given Hooper once per round.
 
-1. Energized: this Hooper can make a Hustle Play on your turn.
-2. Normal
-3. Exhausted: this Hooper cannot do anything during your turn.
-
-During your turn, you can take two actions with a single Hooper if they are Energized. This is called a Hustle Play. After doing this, move the Hooper to the Exhausted state. This means that on their next turn, they cannot take any actions. 
-
-On your turn, if you do not take an Action with a Hooper, move them up the Energy Status if you can.
+*Note*: When all 3 Hoopers have Action cards in front of them, you still have an opportunity to do a Hustle Play. You may also pass, meaning that you will forego the opportunity to do a Hustle Play. The round ends once the Offense and Defense both pass. 
 
 ### Activating
-Each Hooper also has a special perk for being Activated. Each Hooper gets Activated differently. Some need to do specific things multiple times (for example: hit two 3-pointers), while others just need specific circumstances to happen (for example: when your opponent has 10 or more points).
+Each Hooper also has a special perk for being Activated. Each Hooper gets Activated differently. Some need to do specific things multiple times (for example: hit two 3-pointers), while others just need specific circumstances to happen (for example: when your opponent has 6 or more points).
 
-When one of your Hoopers Activates, flip their Card and their Chit to the Activated side so it is clear that they now have their special ability.
+When one of your Hoopers Activates, flip their Card to the Activated side so it is clear that they now have their special ability.
 
 ## End of Game
-The game ends when a team has more than 15 points, and it is not tied. Since Yellow always goes first, Purple must always take the last turn. 
+The game ends when a team has more than 11 points, and it is not tied. Since Yellow always goes first, Purple must always take the last turn. 

--- a/rules.md
+++ b/rules.md
@@ -59,7 +59,7 @@ The action deck has a relatively small number of options. The effect of each act
 The number of spaces a Hooper with this action is determined by their Speed. 
 
 - Your Hooper may move into the space of an opposing Hooper. But you cannot have 2 of our own Hoopers on a space.
-- Screens: With your final move, you may move halfway into another space. This indicates that you are setting a screen between the two spaces. While your Hooper is there, Hoopers from the other team can move between these spaces along the border where you are setting your screen. Other Hoopers may still occupy each of the spaces your Hooper is screening between.
+- Screens: When you are done moving, even if you have no moves remaining, you may place your Hooper on the border between two spaces (you cannot do this if the Hooper you're moving has the ball). This indicates that you are setting a screen between the two spaces. While your Hooper is there, Hoopers from the other team can move between these spaces along the border where you are setting your screen. While your Hooper is there, they cannot receive passes, their Defense numbers are considered zero, and they do not count toward reboundings numbers. 
 
 When the Shot Clock is on 3, **all Hoopers** get +3 their normal movement speed. 
 

--- a/rules.md
+++ b/rules.md
@@ -61,6 +61,8 @@ The number of spaces a Hooper with this action is determined by their Speed.
 - Your Hooper may move into the space of an opposing Hooper. But you cannot have 2 of our own Hoopers on a space.
 - Screens: With your final move, you may move halfway into another space. This indicates that you are setting a screen between the two spaces. While your Hooper is there, Hoopers from the other team can move between these spaces along the border where you are setting your screen. Other Hoopers may still occupy each of the spaces your Hooper is screening between.
 
+When the Shot Clock is on 3, **all Hoopers** get +3 their normal movement speed. 
+
 #### Pass
 If your Hooper has the ball, they may pass it to any teammate. However, you must roll the Ball to determine if it was successful. Find all opponent Hoopers who are on the passer's space, or the receiver's space. Tally up the total defense stats of the opponents in all Defensive spaces. That is your difficulty score. Roll to Ball. If your roll is higher than that number, the pass is complete. If not, the defending team takes the ball, and begins their possession. The defense may give the ball to any of their Hoopers in the passer's space, or the intended recipient's space.
 


### PR DESCRIPTION
<div dir="ltr" style="margin-left:0pt;" align="center" id="docs-internal-guid-478f59c8-7fff-81c3-b19e-5e857e82d55a">
Problem | Solution
-- | --
5v5 is too much to process | 3v3. Guard, Forward, CenterThis also means that there should be fewer, larger spaces on the boardThe beginner game starts with recommended hoopers. Advanced game starts with a school yard pick, and optional bans.
Previous gameplay was too rigid and took too long between player turns | New gameplay loop: Both players prepare a card facedown in front of each of their players. Beginning with the offense, players take turns revealing a card and resolving it immediatelyYou can choose to NOT do the thing indicated on your card, for a penalty: +5 difficulty for passing or shooting, or movement speed cut in half, rounded down.
The game needs to be full court | Make it full court
Passing and Shooting are too difficult | Nerf the defense numbers. Take another look at the shooting difficulty numbers on the board.Also, passing difficulty should only take into consideration the players on the passer’s space and the recipient’s space.
Height is too confusing of a thing | Collapse “hands” and “height” into a singular defense stat. These count toward shooting difficulty and passing difficulty
Unclear how possession change happens. | Immediately reset all hooper actions, whether rebound, turnover, or made basket.
It feels tiresome to have to run all the way to the other side of the court | When the offense has the ball in the back court, all players get +3 move
Not clear enough when you can make a hustle play | On your turn, you may reveal a facedown action card and resolve it, OR make a hustle play: play another card from your hand on one of your Hoopers whose action was already revealed. After all 3 of your Hoopers are face-up, you will still get one more turn where you may make a hustle play. You can only make one hustle play per round.
Didn’t even have rules for rebounding, lol | Let’s start with something wildly simple. The board has clear arcs originating from the hoop. Hoopers under the hoop get rebound. Then whichever player has more hoopers in the next arc. And so on. Tie always goes to the defense. If you get the rebound and you have multiple hoopers in that region, you decide which gets it.
Possessions are too long | Now possessions are simply 3 rounds. You get to take an action with each of your hoopers, thrice. I guess this resets if you get an offensive rebound? Let’s be sure we don’t get into an infinite loop with an excellent rebounder
Old hoopers are probably out of sync with new rules | Revise them all. Add some new conceptsAdd a hooper who wants to hustle all the timeA hooper who wants to improvise
Game doesn’t have an ending | Can we just say first to 11 points or something?

</div>